### PR TITLE
Implement compact mode as floating translucent overlay

### DIFF
--- a/src/voxlink/app.py
+++ b/src/voxlink/app.py
@@ -134,8 +134,10 @@ def run_app(config_path: str | None = None) -> int:
         _play_audio_filtered, Qt.ConnectionType.DirectConnection)
 
     # Wire talking indicator (queued to main thread for UI safety)
-    mumble_client.audio_received_from_user.connect(
-        lambda session_id, pcm_data: main_window.channel_tree.set_user_talking(session_id))
+    def _on_user_audio(session_id: int, pcm_data: bytes) -> None:
+        main_window.channel_tree.set_user_talking(session_id)
+        main_window.compact_overlay.set_user_talking(session_id)
+    mumble_client.audio_received_from_user.connect(_on_user_audio)
 
     # Wire mumble events to UI
     mumble_client.events.connected.connect(main_window.on_connected)

--- a/src/voxlink/ui/compact_overlay.py
+++ b/src/voxlink/ui/compact_overlay.py
@@ -1,0 +1,225 @@
+"""Compact floating overlay showing channel users and talking state."""
+
+from __future__ import annotations
+
+import time
+import logging
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import Qt, QTimer, QPoint, Signal
+from PySide6.QtGui import QColor, QPainter, QBrush, QPen, QFont, QMouseEvent
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QSizePolicy
+
+if TYPE_CHECKING:
+    from PySide6.QtWidgets import QMainWindow
+
+logger = logging.getLogger(__name__)
+
+# Talking indicator colors
+_COLOR_TALKING = QColor("#4ade80")
+_COLOR_IDLE = QColor(180, 180, 180)
+_COLOR_BG = QColor(30, 30, 30, 200)  # semi-transparent dark
+_COLOR_BG_LIGHT = QColor(240, 240, 240, 200)  # semi-transparent light
+_COLOR_BORDER = QColor(80, 80, 80, 150)
+
+
+class _UserRow(QWidget):
+    """Single user row in the compact overlay."""
+
+    def __init__(self, name: str, session_id: int, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.session_id = session_id
+        self._talking = False
+        self._last_spoke: float | None = None
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 2, 6, 2)
+        layout.setSpacing(6)
+
+        # Talking indicator dot
+        self._dot = QLabel()
+        self._dot.setFixedSize(10, 10)
+        self._update_dot()
+        layout.addWidget(self._dot)
+
+        # Username
+        self._name_label = QLabel(name)
+        self._name_label.setStyleSheet("color: white; font-size: 12px;")
+        layout.addWidget(self._name_label, 1)
+
+        # Time since last spoke
+        self._time_label = QLabel("")
+        self._time_label.setStyleSheet("color: rgba(255,255,255,0.5); font-size: 10px;")
+        self._time_label.setMinimumWidth(30)
+        self._time_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(self._time_label)
+
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        self.setFixedHeight(24)
+
+    def set_talking(self, talking: bool) -> None:
+        self._talking = talking
+        if talking:
+            self._last_spoke = time.monotonic()
+        self._update_dot()
+
+    def update_time_label(self) -> None:
+        if self._talking:
+            self._time_label.setText("")
+            return
+        if self._last_spoke is None:
+            self._time_label.setText("")
+            return
+        elapsed = time.monotonic() - self._last_spoke
+        if elapsed < 60:
+            self._time_label.setText(f"{int(elapsed)}s")
+        elif elapsed < 3600:
+            self._time_label.setText(f"{int(elapsed // 60)}m")
+        else:
+            self._time_label.setText("")
+            self._last_spoke = None  # stop showing after 1h
+
+    def _update_dot(self) -> None:
+        color = _COLOR_TALKING if self._talking else _COLOR_IDLE
+        self._dot.setStyleSheet(
+            f"background-color: {color.name()}; "
+            f"border-radius: 5px; "
+            f"min-width: 10px; max-width: 10px; "
+            f"min-height: 10px; max-height: 10px;"
+        )
+
+
+class CompactOverlay(QWidget):
+    """Floating translucent overlay showing users and talking state.
+
+    Signals:
+        restore_requested: Emitted when user wants to return to full app.
+    """
+
+    restore_requested = Signal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(
+            parent,
+            Qt.WindowType.Window
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Tool,
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setMinimumWidth(180)
+        self.setMaximumWidth(280)
+
+        self._user_rows: dict[int, _UserRow] = {}  # session_id -> row
+        self._drag_pos: QPoint | None = None
+
+        # Main layout
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(0)
+
+        # Header
+        self._header = QLabel("  VoxLink")
+        self._header.setStyleSheet(
+            "color: #4ade80; font-size: 11px; font-weight: bold; padding: 4px 6px;"
+        )
+        self._header.setFixedHeight(22)
+        self._layout.addWidget(self._header)
+
+        # User list container
+        self._user_container = QWidget()
+        self._user_layout = QVBoxLayout(self._user_container)
+        self._user_layout.setContentsMargins(0, 0, 0, 0)
+        self._user_layout.setSpacing(0)
+        self._layout.addWidget(self._user_container)
+
+        # Update timer for "last spoke" labels
+        # Fast timer for talking decay (200ms) and time label updates
+        self._update_timer = QTimer(self)
+        self._update_timer.timeout.connect(self._update_time_labels)
+        self._update_timer.start(200)
+
+        self.adjustSize()
+
+    def paintEvent(self, event) -> None:
+        """Draw rounded semi-transparent background."""
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setBrush(QBrush(_COLOR_BG))
+        painter.setPen(QPen(_COLOR_BORDER, 1))
+        painter.drawRoundedRect(self.rect().adjusted(0, 0, -1, -1), 8, 8)
+        painter.end()
+
+    def set_users(self, users: dict) -> None:
+        """Update the user list. users: {session_id: {"name": str, ...}}"""
+        current_sessions = set(self._user_rows.keys())
+        new_sessions = set()
+
+        for session_id, user_data in users.items():
+            new_sessions.add(session_id)
+            if session_id not in self._user_rows:
+                row = _UserRow(user_data.get("name", "Unknown"), session_id)
+                self._user_rows[session_id] = row
+                self._user_layout.addWidget(row)
+
+        # Remove users that left
+        for session_id in current_sessions - new_sessions:
+            row = self._user_rows.pop(session_id)
+            self._user_layout.removeWidget(row)
+            row.deleteLater()
+
+        self.adjustSize()
+
+    def add_user(self, session_id: int, name: str) -> None:
+        if session_id not in self._user_rows:
+            row = _UserRow(name, session_id)
+            self._user_rows[session_id] = row
+            self._user_layout.addWidget(row)
+            self.adjustSize()
+
+    def remove_user(self, session_id: int) -> None:
+        row = self._user_rows.pop(session_id, None)
+        if row is not None:
+            self._user_layout.removeWidget(row)
+            row.deleteLater()
+            self.adjustSize()
+
+    def set_user_talking(self, session_id: int) -> None:
+        row = self._user_rows.get(session_id)
+        if row is not None:
+            row.set_talking(True)
+
+    def clear_users(self) -> None:
+        for row in self._user_rows.values():
+            self._user_layout.removeWidget(row)
+            row.deleteLater()
+        self._user_rows.clear()
+        self.adjustSize()
+
+    def _update_time_labels(self) -> None:
+        for row in self._user_rows.values():
+            # Decay talking state after 200ms of no audio
+            if row._talking and row._last_spoke is not None:
+                if time.monotonic() - row._last_spoke > 0.2:
+                    row.set_talking(False)
+            row.update_time_label()
+
+    # ---- Dragging ----
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._drag_pos = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
+            event.accept()
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        if self._drag_pos is not None and event.buttons() & Qt.MouseButton.LeftButton:
+            self.move(event.globalPosition().toPoint() - self._drag_pos)
+            event.accept()
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        self._drag_pos = None
+
+    def mouseDoubleClickEvent(self, event: QMouseEvent) -> None:
+        """Double-click to restore full app."""
+        self.restore_requested.emit()
+        event.accept()

--- a/src/voxlink/ui/main_window.py
+++ b/src/voxlink/ui/main_window.py
@@ -20,6 +20,7 @@ from qfluentwidgets import (
 from qfluentwidgets.components.dialog_box.message_box_base import MessageBoxBase
 
 from voxlink.ui.channel_tree import ChannelTree
+from voxlink.ui.compact_overlay import CompactOverlay
 from voxlink.ui.status_bar import StatusBar
 
 if TYPE_CHECKING:
@@ -139,6 +140,8 @@ class MainWindow(FluentWindow):
         self._tray_icon = None
         self._is_muted = False
         self._is_deafened = False
+        self._compact_overlay = CompactOverlay()
+        self._compact_overlay.restore_requested.connect(self._restore_from_compact)
 
         # Setup
         self.setWindowTitle("VoxLink")
@@ -183,6 +186,16 @@ class MainWindow(FluentWindow):
             position=NavigationItemPosition.BOTTOM,
         )
 
+        # Compact mode toggle in nav
+        self.navigationInterface.addItem(
+            routeKey="compact",
+            icon=FluentIcon.MINIMIZE,
+            text="Compact",
+            onClick=self._enter_compact_mode,
+            selectable=False,
+            position=NavigationItemPosition.BOTTOM,
+        )
+
         # About in bottom nav
         self.navigationInterface.addItem(
             routeKey="about",
@@ -195,10 +208,6 @@ class MainWindow(FluentWindow):
 
         self._restore_geometry()
 
-        # Apply compact mode from config
-        if config.ui.compact_mode:
-            self.navigationInterface.setExpandWidth(48)
-
     # ---- Properties for external wiring ----
 
     @property
@@ -208,6 +217,10 @@ class MainWindow(FluentWindow):
     @property
     def status_bar_widget(self) -> StatusBar:
         return self._server_page.status_bar
+
+    @property
+    def compact_overlay(self) -> CompactOverlay:
+        return self._compact_overlay
 
     def set_tray_icon(self, tray_icon) -> None:
         """Store reference to tray icon for minimize-to-tray behavior."""
@@ -244,6 +257,7 @@ class MainWindow(FluentWindow):
         self._server_page.channel_tree.clear()
         self._server_page.channel_tree.setHeaderLabel("Channels")
         self._server_page.info_area.append("Disconnected from server.")
+        self._compact_overlay.clear_users()
 
     def on_error(self, message: str) -> None:
         """Handle connection error."""
@@ -262,15 +276,20 @@ class MainWindow(FluentWindow):
     def on_user_joined(self, user_data: dict) -> None:
         """Handle user joining."""
         name = user_data.get("name", "Unknown")
+        session = user_data.get("session")
         self._server_page.info_area.append(f"User joined: {name}")
-        # Full refresh to ensure channel tree is up-to-date
         self._refresh_tree()
+        if session is not None:
+            self._compact_overlay.add_user(session, name)
 
     def on_user_left(self, user_data: dict) -> None:
         """Handle user leaving."""
         name = user_data.get("name", "Unknown")
+        session = user_data.get("session")
         self._server_page.info_area.append(f"User left: {name}")
         self._server_page.channel_tree.remove_user(user_data)
+        if session is not None:
+            self._compact_overlay.remove_user(session)
 
     # ---- Actions ----
 
@@ -312,6 +331,22 @@ class MainWindow(FluentWindow):
     def _toggle_deafen(self) -> None:
         self._is_deafened = not self._is_deafened
         self._server_page.status_bar.set_deafened(self._is_deafened)
+
+    def _enter_compact_mode(self) -> None:
+        """Switch to compact floating overlay."""
+        self._save_geometry()
+        self.hide()
+        # Sync current users to overlay
+        users = self._mumble_client.get_users()
+        self._compact_overlay.set_users(users)
+        self._compact_overlay.show()
+
+    def _restore_from_compact(self) -> None:
+        """Restore from compact overlay to full window."""
+        self._compact_overlay.hide()
+        self.show()
+        self.raise_()
+        self.activateWindow()
 
     def _on_mute_toggled(self, muted: bool) -> None:
         self._is_muted = muted

--- a/src/voxlink/ui/settings.py
+++ b/src/voxlink/ui/settings.py
@@ -381,16 +381,6 @@ class SettingsPage(ScrollArea):
         tray_layout.addWidget(self._show_tray_switch)
         self._layout.addWidget(self._tray_card)
 
-        # Compact mode
-        self._compact_card = SimpleCardWidget()
-        compact_layout = QHBoxLayout(self._compact_card)
-        compact_layout.setContentsMargins(16, 8, 16, 8)
-        compact_layout.addWidget(BodyLabel("Compact Mode"))
-        compact_layout.addStretch()
-        self._compact_switch = SwitchButton()
-        self._compact_switch.checkedChanged.connect(self._on_compact_toggled)
-        compact_layout.addWidget(self._compact_switch)
-        self._layout.addWidget(self._compact_card)
 
     # ---- Actions ----
 
@@ -448,7 +438,6 @@ class SettingsPage(ScrollArea):
             self._theme_combo.setCurrentIndex(theme_idx)
         self._start_minimized_switch.setChecked(cfg.ui.start_minimized)
         self._show_tray_switch.setChecked(cfg.ui.show_tray_icon)
-        self._compact_switch.setChecked(cfg.ui.compact_mode)
 
     def _apply_settings(self) -> None:
         """Write widget values back to config."""
@@ -480,7 +469,6 @@ class SettingsPage(ScrollArea):
         cfg.ui.theme = self._theme_map.get(theme_text, "auto")
         cfg.ui.start_minimized = self._start_minimized_switch.isChecked()
         cfg.ui.show_tray_icon = self._show_tray_switch.isChecked()
-        cfg.ui.compact_mode = self._compact_switch.isChecked()
 
         try:
             cfg.save()
@@ -496,19 +484,6 @@ class SettingsPage(ScrollArea):
         _map = {"System": Theme.AUTO, "Dark": Theme.DARK, "Light": Theme.LIGHT}
         setTheme(_map.get(text, Theme.AUTO))
 
-    def _on_compact_toggled(self, checked: bool) -> None:
-        """Toggle compact mode on the main window's navigation sidebar."""
-        main_win = self.window()
-        if hasattr(main_win, 'navigationInterface'):
-            nav = main_win.navigationInterface
-            if checked:
-                nav.setMinimumWidth(48)
-                nav.setExpandWidth(48)
-                nav.panel.setMinimumWidth(48)
-            else:
-                nav.setMinimumWidth(48)
-                nav.setExpandWidth(322)
-                nav.panel.setMinimumWidth(48)
 
     def _on_bind_ptt_key(self) -> None:
         """Start PTT key binding process."""


### PR DESCRIPTION
## Summary

- Replaces broken compact mode (sidebar collapse) with a floating translucent overlay window
- Shows users with green talking indicator dots and "time since last spoke" labels
- Always-on-top, draggable, semi-transparent, double-click to restore full app
- Adds "Compact" button to navigation sidebar

## Details

- New `CompactOverlay` widget: frameless, translucent, stays on top, draggable
- Per-user rows with talking dot (green = talking, grey = idle) and elapsed time
- 200ms decay timer for talking state, 1s update for time labels
- Syncs with user join/leave/disconnect events
- Removes old broken compact mode toggle from Settings

Closes #1

## Test plan

- [ ] Click "Compact" in sidebar — main window hides, overlay appears
- [ ] Verify overlay is translucent and stays on top of other windows
- [ ] Drag the overlay to reposition it
- [ ] Verify users appear in the overlay when connected
- [ ] Have another user speak — green dot should appear and fade after they stop
- [ ] Verify "Xs" time label appears after user stops speaking
- [ ] Double-click overlay to restore full app
- [ ] Disconnect — overlay should clear users

🤖 Generated with [Claude Code](https://claude.com/claude-code)