### PR TITLE
Fix PKGBUILD git source and reconnect bug

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,7 +27,7 @@ source=("git+https://github.com/csjohnst/voxlink.git#tag=v${pkgver}")
 sha256sums=('SKIP')
 
 build() {
-    cd "$srcdir/voxlink"
+    cd "$srcdir/$pkgname"
 
     # Create isolated venv for building
     python -m venv --system-site-packages buildenv
@@ -43,7 +43,7 @@ build() {
 }
 
 package() {
-    cd "$srcdir/voxlink"
+    cd "$srcdir/$pkgname"
 
     # Install binary
     install -Dm755 "dist/voxlink" "$pkgdir/usr/bin/voxlink"

--- a/src/voxlink/mumble/client.py
+++ b/src/voxlink/mumble/client.py
@@ -387,9 +387,13 @@ class MumbleClient(QObject):
                 port=resolved_port,
                 reconnect=False,  # we handle reconnect ourselves
                 force_tcp_only=True,
-                debug=True,
             )
             self._mumble.daemon = True
+            # pymumble captures threading.current_thread() as parent_thread
+            # and exits its main loop when parent_thread dies. On reconnect,
+            # we're called from a threading.Timer thread that dies immediately
+            # after connect_to_server returns. Pin to the main thread instead.
+            self._mumble.parent_thread = threading.main_thread()
 
             # Patch to handle legacy audio format from older servers/clients
             _patch_sound_received(self._mumble)


### PR DESCRIPTION
## Summary
- **PKGBUILD**: Changed from local-only build (`source=()`, `cd "$startdir"`) to a proper distributable PKGBUILD that fetches from git via `#tag=v${pkgver}`. Created and pushed the `v0.1.0` tag on master.
- **Reconnect bug**: Fixed pymumble's `parent_thread` dying on reconnect — `threading.Timer` thread exits after `connect_to_server` returns, causing pymumble's main loop to exit immediately. Now pinned to `threading.main_thread()`.
- **Removed `debug=True`** from pymumble constructor (was causing duplicate log handlers).

## Test plan
- [ ] `makepkg -si` succeeds in a clean directory with only the PKGBUILD
- [ ] App reconnects successfully after a server disconnect

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)