### PR TITLE
Add uninstall script and deprecate legacy install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 set -e
+
+echo "WARNING: This install method is deprecated."
+echo "The preferred installation method is: makepkg -si"
+echo "See README.md for details."
+echo ""
+read -rp "Continue with legacy venv install anyway? [y/N] " reply
+if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+  echo "Aborted. Use 'makepkg -si' instead."
+  exit 0
+fi
+
 echo "=== VoxLink Installer for Arch Linux ==="
 
 # System deps

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+echo "=== VoxLink Uninstaller ==="
+
+# Desktop file
+if [ -f ~/.local/share/applications/voxlink.desktop ]; then
+  rm ~/.local/share/applications/voxlink.desktop
+  echo "Removed desktop entry"
+fi
+
+# Icon
+if [ -f ~/.local/share/icons/hicolor/scalable/apps/voxlink.svg ]; then
+  rm ~/.local/share/icons/hicolor/scalable/apps/voxlink.svg
+  echo "Removed icon"
+fi
+
+# Launcher script
+if [ -f ~/.local/bin/voxlink ]; then
+  rm ~/.local/bin/voxlink
+  echo "Removed launcher script"
+fi
+
+# Virtual environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -d "$SCRIPT_DIR/.venv" ]; then
+  rm -rf "$SCRIPT_DIR/.venv"
+  echo "Removed virtual environment"
+fi
+
+echo ""
+echo "=== Uninstall complete! ==="
+echo "System packages (python, pipewire, etc.) were not removed."
+echo "Remove the project directory manually if desired: rm -rf $SCRIPT_DIR"


### PR DESCRIPTION
## Summary
- Added `uninstall.sh` to clean up files placed by the legacy `install.sh` (desktop entry, icon, launcher script, venv)
- Added deprecation warning to `install.sh` prompting users to use `makepkg -si` instead

## Test plan
- [ ] Run `uninstall.sh` after a legacy install — verify all files are removed
- [ ] Run `install.sh` — verify deprecation warning appears and `N` aborts

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)