### PR TITLE
Broadcast mute/deafen state to other clients

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Chris Johnston
 pkgname=voxlink
-pkgver=0.1.4
+pkgver=0.1.5
 pkgrel=1
 pkgdesc="Wayland-native Mumble voice chat client"
 arch=('x86_64')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "voxlink"
-version = "0.1.4"
+version = "0.1.5"
 description = "Wayland-native Mumble voice chat client for Arch Linux"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/voxlink/mumble/client.py
+++ b/src/voxlink/mumble/client.py
@@ -617,6 +617,29 @@ class MumbleClient(QObject):
         except Exception:
             logger.exception("Failed to send audio")
 
+    def set_self_mute(self, muted: bool) -> None:
+        """Send self-mute state to the server."""
+        if self._mumble is None or self._state != ConnectionState.CONNECTED:
+            return
+        try:
+            self._mumble.users.myself.self_mute = muted
+            logger.info("Set self_mute=%s on server", muted)
+        except Exception:
+            logger.exception("Failed to set self_mute")
+
+    def set_self_deaf(self, deafened: bool) -> None:
+        """Send self-deaf state to the server."""
+        if self._mumble is None or self._state != ConnectionState.CONNECTED:
+            return
+        try:
+            self._mumble.users.myself.self_deaf = deafened
+            if deafened:
+                # Deafen implies mute in Mumble protocol
+                self._mumble.users.myself.self_mute = True
+            logger.info("Set self_deaf=%s on server", deafened)
+        except Exception:
+            logger.exception("Failed to set self_deaf")
+
     def join_channel(self, channel_id: int) -> None:
         """Join a channel by ID."""
         if self._mumble is None or self._state != ConnectionState.CONNECTED:

--- a/src/voxlink/ui/main_window.py
+++ b/src/voxlink/ui/main_window.py
@@ -378,11 +378,15 @@ class MainWindow(FluentWindow):
         if muted:
             self._capture_manager.stop()
         # Don't auto-start capture on unmute - PTT controls that
+        self._mumble_client.set_self_mute(muted)
         logger.info("Mute %s", "enabled" if muted else "disabled")
 
     def _on_deafen_toggled(self, deafened: bool) -> None:
         self._is_deafened = deafened
-        # Store the deafen state; the app.py audio_received handler checks it
+        self._mumble_client.set_self_deaf(deafened)
+        if not deafened:
+            # Undeafen should also unmute on the server
+            self._mumble_client.set_self_mute(self._is_muted)
         logger.info("Deafen %s", "enabled" if deafened else "disabled")
 
     def _restore_geometry(self) -> None:


### PR DESCRIPTION
## Summary
- Added `set_self_mute()` and `set_self_deaf()` to `MumbleClient` that send `UserState` protobuf messages to the server via pymumble
- Wired mute/deafen UI toggles to call these methods so other clients see the status
- Deafen implies mute in Mumble protocol; undeafen restores the correct mute state

## Test plan
- [ ] Mute in VoxLink — other Mumble clients show muted icon
- [ ] Deafen in VoxLink — other clients show deafened icon
- [ ] Unmute/undeafen — other clients see the state cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)